### PR TITLE
First pass at reducing memory usage

### DIFF
--- a/src/Cose.c
+++ b/src/Cose.c
@@ -203,11 +203,10 @@ errorReturn:
 	return NULL;
 }
 
-byte RgbDontUse[8 * 1024];   //  Remove this array when we can compute the size of a cbor serialization without this hack.
 
 size_t COSE_Encode(HCOSE msg, byte * rgb, size_t ib, size_t cb)
 {
-	if (rgb == NULL) return cn_cbor_encoder_write(RgbDontUse, 0, sizeof(RgbDontUse), ((COSE *)msg)->m_cbor) + ib;
+	if (rgb == NULL) return cn_cbor_encode_size(((COSE *)msg)->m_cbor) + ib;
 	return cn_cbor_encoder_write(rgb, ib, cb, ((COSE*)msg)->m_cbor);
 }
 
@@ -313,8 +312,6 @@ errorReturn:
 	return f;
 }
 
-byte RgbDontUse3[1024];
-
 cn_cbor * _COSE_encode_protected(COSE * pMessage, cose_errback * perr)
 {
 	cn_cbor * pProtected;
@@ -332,7 +329,7 @@ cn_cbor * _COSE_encode_protected(COSE * pMessage, cose_errback * perr)
 	}
 
 	if (pMessage->m_protectedMap->length > 0) {
-		cbProtected = cn_cbor_encoder_write(RgbDontUse3, 0, sizeof(RgbDontUse3), pMessage->m_protectedMap);
+		cbProtected = cn_cbor_encode_size(pMessage->m_protectedMap);
 		pbProtected = (byte *)COSE_CALLOC(cbProtected, 1, context);
 		CHECK_CONDITION(pbProtected != NULL, COSE_ERR_OUT_OF_MEMORY);
 

--- a/src/Encrypt.c
+++ b/src/Encrypt.c
@@ -14,8 +14,6 @@
 
 void _COSE_Enveloped_Release(COSE_Enveloped * p);
 
-byte RgbDontUse[8 * 1024];   //  Remove this array when we can compute the size of a cbor serialization without this hack.
-
 COSE * EnvelopedRoot = NULL;
 
 /*! \private
@@ -824,7 +822,7 @@ bool _COSE_Encrypt_Build_AAD(COSE * pMessage, byte ** ppbAAD, size_t * pcbAAD, c
 	CHECK_CONDITION_CBOR(cn_cbor_array_append(pAuthData, ptmp, &cbor_error), cbor_error);
 	ptmp = NULL;
 
-	cbAuthData = cn_cbor_encoder_write(RgbDontUse, 0, sizeof(RgbDontUse), pAuthData);
+	cbAuthData = cn_cbor_encode_size(pAuthData);
 	pbAuthData = (byte *)COSE_CALLOC(cbAuthData, 1, context);
 	CHECK_CONDITION(pbAuthData != NULL, COSE_ERR_OUT_OF_MEMORY);
 	CHECK_CONDITION((size_t)cn_cbor_encoder_write(pbAuthData, 0, cbAuthData, pAuthData) == cbAuthData, COSE_ERR_CBOR);

--- a/src/Encrypt0.c
+++ b/src/Encrypt0.c
@@ -12,8 +12,6 @@
 #include "configure.h"
 #include "crypto.h"
 
-byte RgbDontUse[8 * 1024];   //  Remove this array when we can compute the size of a cbor serialization without this hack.
-
 void _COSE_Encrypt_Release(COSE_Encrypt * p);
 
 COSE * EncryptRoot = NULL;

--- a/src/MacMessage.c
+++ b/src/MacMessage.c
@@ -13,8 +13,6 @@
 #include "configure.h"
 #include "crypto.h"
 
-byte RgbDontUse2[8 * 1024];   //  Remove this array when we can compute the size of a cbor serialization without this hack.
-
 COSE * MacRoot = NULL;
 
 /*! \private
@@ -279,7 +277,7 @@ bool _COSE_Mac_Build_AAD(COSE * pCose, char * szContext, byte ** ppbAuthData, si
 	ptmp = NULL;
 
 	//  Turn it into bytes
-	cbAuthData = cn_cbor_encoder_write(RgbDontUse2, 0, sizeof(RgbDontUse2), pAuthData);
+	cbAuthData = cn_cbor_encode_size(pAuthData);
 	CHECK_CONDITION(cbAuthData > 0, COSE_ERR_CBOR);
 	pbAuthData = (byte *)COSE_CALLOC(cbAuthData, 1, context);
 	CHECK_CONDITION(pbAuthData != NULL, COSE_ERR_OUT_OF_MEMORY);

--- a/src/Recipient.c
+++ b/src/Recipient.c
@@ -1203,8 +1203,6 @@ errorReturn:
 }
 
 
-byte RgbDontUse4[8 * 1024];
-
 bool BuildContextBytes(COSE * pcose, int algID, size_t cbitKey, byte ** ppbContext, size_t * pcbContext, CBOR_CONTEXT_COMMA cose_errback * perr)
 {
 	cn_cbor * pArray;
@@ -1335,7 +1333,7 @@ bool BuildContextBytes(COSE * pcose, int algID, size_t cbitKey, byte ** ppbConte
 		cnParam = NULL;
 	}
 
-	cbContext = cn_cbor_encoder_write(RgbDontUse4, 0, sizeof(RgbDontUse4), pArray);
+	cbContext = cn_cbor_encode_size(pArray);
 	CHECK_CONDITION(cbContext > 0, COSE_ERR_CBOR);
 	pbContext = (byte *)COSE_CALLOC(cbContext, 1, context);
 	CHECK_CONDITION(pbContext != NULL, COSE_ERR_OUT_OF_MEMORY);

--- a/src/Sign0.c
+++ b/src/Sign0.c
@@ -246,9 +246,6 @@ errorReturn:
 }
 
 
-byte RgbDontUse4[8 * 1024];
-byte RgbDontUseSign[8 * 1024];
-
 static bool CreateSign0AAD(COSE_Sign0Message * pMessage, byte ** ppbToSign, size_t * pcbToSign, char * szContext, cose_errback * perr)
 {
 	cn_cbor * pArray = NULL;
@@ -290,7 +287,7 @@ static bool CreateSign0AAD(COSE_Sign0Message * pMessage, byte ** ppbToSign, size
 	cn = NULL;
 
 
-	cbToSign = cn_cbor_encoder_write(RgbDontUse4, 0, sizeof(RgbDontUse4), pArray);
+	cbToSign = cn_cbor_encode_size(pArray);
 	CHECK_CONDITION(cbToSign > 0, COSE_ERR_CBOR);
 	pbToSign = (byte *)COSE_CALLOC(cbToSign, 1, context);
 	CHECK_CONDITION(pbToSign != NULL, COSE_ERR_OUT_OF_MEMORY);

--- a/src/SignerInfo.c
+++ b/src/SignerInfo.c
@@ -106,8 +106,6 @@ errorReturn:
 	return NULL;
 }
 
-byte RgbDontUse4[1024];
-
 bool BuildToBeSigned(byte ** ppbToSign, size_t * pcbToSign, const cn_cbor * pcborBody, const cn_cbor * pcborProtected, const cn_cbor * pcborProtectedSign, const byte * pbExternal, size_t cbExternal, CBOR_CONTEXT_COMMA cose_errback * perr)
 {
 	cn_cbor * pArray = NULL;
@@ -147,7 +145,7 @@ bool BuildToBeSigned(byte ** ppbToSign, size_t * pcbToSign, const cn_cbor * pcbo
 	CHECK_CONDITION_CBOR(cn_cbor_array_append(pArray, cn, &cbor_error), cbor_error);
 	cn = NULL;
 
-	cbToSign = cn_cbor_encoder_write(RgbDontUse4, 0, sizeof(RgbDontUse4), pArray);
+	cbToSign = cn_cbor_encode_size(pArray);
 	CHECK_CONDITION(cbToSign > 0, COSE_ERR_CBOR);
 	pbToSign = (byte *)COSE_CALLOC(cbToSign, 1, context);
 	CHECK_CONDITION(pbToSign != NULL, COSE_ERR_OUT_OF_MEMORY);

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -183,3 +183,11 @@ cn_cbor * cn_cbor_null_create(CBOR_CONTEXT_COMMA cn_cbor_errback * errp)
 	pcn->type = CN_CBOR_NULL;
 	return pcn;
 }
+
+
+byte RgbDontUse4[8 * 1024];
+
+size_t cn_cbor_encode_size(cn_cbor * object)
+{
+	return cn_cbor_encoder_write(RgbDontUse4, 0, sizeof(RgbDontUse4), object);
+}

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -185,7 +185,7 @@ cn_cbor * cn_cbor_null_create(CBOR_CONTEXT_COMMA cn_cbor_errback * errp)
 }
 
 
-byte RgbDontUse4[8 * 1024];
+unsigned char RgbDontUse4[8 * 1024];
 
 size_t cn_cbor_encode_size(cn_cbor * object)
 {

--- a/src/cose_int.h
+++ b/src/cose_int.h
@@ -270,6 +270,7 @@ cn_cbor * _COSE_arrayget_int(COSE * pMessage, int index);
 bool cn_cbor_array_replace(cn_cbor * cb_array, cn_cbor * cb_value, int index, CBOR_CONTEXT_COMMA cn_cbor_errback *errp);
 cn_cbor * cn_cbor_bool_create(int boolValue, CBOR_CONTEXT_COMMA cn_cbor_errback * errp);
 
+extern size_t cn_cbor_encode_size(cn_cbor * object);
 
 enum {
 	COSE_Int_Alg_AES_CBC_MAC_256_64 = -22


### PR DESCRIPTION
Since we have not gotten a fix from cn-cbor yet on this problem, move to a single location of a static buffer for encoding into to get the actual size needed.  Now use just the one 8K buffer.