### PR TITLE
Let's do a warning removal pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - cmake --version
   - git clone --depth 1 git://github.com/cose-wg/Examples Examples
   - mkdir build
-  - cd build && cmake -Duse_context=$USE_CONTEXT -Dcoveralls=$COVERALL_SEND  -Duse_embedtls=$USE_EMBEDTLS .. && make all test
+  - cd build && cmake -Duse_context=$USE_CONTEXT -Dcoveralls=$COVERALL_SEND $coveralls_send=$COVERALL_SEND  -Duse_embedtls=$USE_EMBEDTLS .. && make all test
 
 after_success:
   - make coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - cmake --version
   - git clone --depth 1 git://github.com/cose-wg/Examples Examples
   - mkdir build
-  - cd build && cmake -Duse_context=$USE_CONTEXT -Dcoveralls_send=$COVERALL_SEND  -Duse_embedtls=$USE_EMBEDTLS .. && make all test
+  - cd build && cmake -Duse_context=$USE_CONTEXT -Dcoveralls=$COVERALL_SEND  -Duse_embedtls=$USE_EMBEDTLS .. && make all test
 
 after_success:
   - make coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - cmake --version
   - git clone --depth 1 git://github.com/cose-wg/Examples Examples
   - mkdir build
-  - cd build && cmake -Duse_context=$USE_CONTEXT -Dcoveralls=$COVERALL_SEND $coveralls_send=$COVERALL_SEND  -Duse_embedtls=$USE_EMBEDTLS .. && make all test
+  - cd build && cmake -Duse_context=$USE_CONTEXT -Dcoveralls=$COVERALL_SEND -Dcoveralls_send=$COVERALL_SEND  -Duse_embedtls=$USE_EMBEDTLS .. && make all test
 
 after_success:
   - make coveralls

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,6 @@ set ( cose_sources
 	cbor.c
 	Encrypt.c
         Encrypt0.c
-	Message.c
 	Recipient.c
 	SignerInfo.c
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,12 +2,16 @@
 #  compiling/installing sources for COSE-C
 #
 
+if (use_embedtls)
+  set (cose_crypto mbedtls.c)
+else ()
+  set (cose_crypto openssl.c)
+endif()
+
 set ( cose_sources 
 	Cose.c
 	MacMessage.c
         MacMessage0.c
-        mbedtls.c
-	openssl.c
 	Sign.c
         Sign0.c
 	cbor.c
@@ -15,7 +19,9 @@ set ( cose_sources
         Encrypt0.c
 	Recipient.c
 	SignerInfo.c
+        ${cose_crypto}
 )
+
 
 if (use_context)
     add_definitions(-DUSE_CBOR_CONTEXT)

--- a/src/Cose.c
+++ b/src/Cose.c
@@ -221,6 +221,7 @@ cn_cbor * COSE_get_cbor(HCOSE h)
 
 bool _COSE_SetExternal(COSE * pcose, const byte * pbExternalData, size_t cbExternalData, cose_errback * perr)
 {
+	(void) perr;
 	pcose->m_pbExternal = pbExternalData;
 	pcose->m_cbExternal = cbExternalData;
 

--- a/src/MacMessage.c
+++ b/src/MacMessage.c
@@ -516,7 +516,7 @@ errorReturn:
 bool _COSE_Mac_validate(COSE_MacMessage * pcose, COSE_RecipientInfo * pRecip, const byte * pbKeyIn, size_t cbKeyIn, const char * szContext, cose_errback * perr)
 {
 	byte * pbAuthData = NULL;
-	int cbitKey = 0;
+	size_t cbitKey = 0;
 	bool fRet = false;
 
 	int alg;

--- a/src/Message.c
+++ b/src/Message.c
@@ -1,9 +1,0 @@
-#include <stdlib.h>
-
-#include "cose.h"
-#include "cose_int.h"
-#include "configure.h"
-#include "crypto.h"
-
-
-

--- a/src/Recipient.c
+++ b/src/Recipient.c
@@ -226,7 +226,7 @@ errorReturn:
 }
 #endif // defined(USE_HKDF_SHA2) || defined(USE_HKDF_AES)
 
-bool _COSE_Recipient_decrypt(COSE_RecipientInfo * pRecip, COSE_RecipientInfo * pRecipUse, int algIn, int cbitKeyOut, byte * pbKeyOut, cose_errback * perr)
+bool _COSE_Recipient_decrypt(COSE_RecipientInfo * pRecip, COSE_RecipientInfo * pRecipUse, int algIn, size_t cbitKeyOut, byte * pbKeyOut, cose_errback * perr)
 {
 	int alg;
 	const cn_cbor * cn = NULL;
@@ -239,14 +239,17 @@ bool _COSE_Recipient_decrypt(COSE_RecipientInfo * pRecip, COSE_RecipientInfo * p
 	COSE_Enveloped * pcose = &pRecip->m_encrypt;
 	cn_cbor * cnBody = NULL;
 	byte * pbContext = NULL;
-	byte rgbKey[256 / 8];
 	byte * pbSecret = NULL;
 	int cbKey2;
 	byte * pbKeyX = NULL;
 	int cbitKeyX = 0;
 
+	UNUSED(pcose);
+
 #ifdef USE_CBOR_CONTEXT
 	context = &pcose->m_message.m_allocContext;
+#else
+	UNUSED(pcose);
 #endif
 
 	cn = _COSE_map_get_int(&pRecip->m_encrypt.m_message, COSE_Header_Algorithm, COSE_BOTH, perr);

--- a/src/Recipient.c
+++ b/src/Recipient.c
@@ -243,6 +243,7 @@ bool _COSE_Recipient_decrypt(COSE_RecipientInfo * pRecip, COSE_RecipientInfo * p
 	int cbKey2;
 	byte * pbKeyX = NULL;
 	int cbitKeyX = 0;
+	byte rgbKey[256 / 8];
 
 	UNUSED(pcose);
 

--- a/src/Sign0.c
+++ b/src/Sign0.c
@@ -385,7 +385,6 @@ bool _COSE_Signer0_validate(COSE_Sign0Message * pSign, const cn_cbor * pKey, cos
 	cn_cbor_context * context = NULL;
 #endif
 	size_t cbToSign;
-	cn_cbor * cnSignature = NULL;
 	bool fRet = false;
 
 #ifdef USE_CBOR_CONTEXT
@@ -407,8 +406,6 @@ bool _COSE_Signer0_validate(COSE_Sign0Message * pSign, const cn_cbor * pKey, cos
 	//  Build protected headers
 
 	if (!CreateSign0AAD(pSign, &pbToSign, &cbToSign, "Signature1", perr)) goto errorReturn;
-
-	cnSignature = _COSE_arrayget_int(&pSign->m_message, INDEX_SIGNATURE);
 
 	switch (alg) {
 #ifdef USE_ECDSA_SHA_256

--- a/src/cose_int.h
+++ b/src/cose_int.h
@@ -215,7 +215,7 @@ extern void _COSE_Sign0_Release(COSE_Sign0Message * p);
 //  Mac-ed items
 extern HCOSE_MAC _COSE_Mac_Init_From_Object(cn_cbor *, COSE_MacMessage * pIn, CBOR_CONTEXT_COMMA cose_errback * errp);
 extern bool _COSE_Mac_Release(COSE_MacMessage * p);
-extern bool _COSE_Mac_Build_AAD(COSE * pCose, char * szContext, byte ** ppbAuthData, size_t * pcbAuthData, CBOR_CONTEXT_COMMA cose_errback * perr);
+extern bool _COSE_Mac_Build_AAD(COSE * pCose, const char * szContext, byte ** ppbAuthData, size_t * pcbAuthData, CBOR_CONTEXT_COMMA cose_errback * perr);
 extern bool _COSE_Mac_compute(COSE_MacMessage * pcose, const byte * pbKeyIn, size_t cbKeyIn, const char * szContext, cose_errback * perr);
 extern bool _COSE_Mac_validate(COSE_MacMessage * pcose, COSE_RecipientInfo * pRecip, const byte * pbKeyIn, size_t cbKeyIn, const char * szContext, cose_errback * perr);
 

--- a/src/cose_int.h
+++ b/src/cose_int.h
@@ -8,6 +8,8 @@ struct _COSE_COUNTER_SIGN;
 typedef struct _COSE_COUNTER_SIGN COSE_CounterSign;
 #endif
 
+#define UNUSED(x) ((void) (x))
+
 typedef struct _COSE {
 	COSE_INIT_FLAGS m_flags;		//  Not sure what goes here yet
 	int m_ownMsg;		//  Do I own the pointer @ m_cbor?
@@ -190,7 +192,7 @@ extern bool _COSE_Encrypt_Build_AAD(COSE * pMessage, byte ** ppbAAD, size_t * pc
 
 extern COSE_RecipientInfo * _COSE_Recipient_Init_From_Object(cn_cbor *, CBOR_CONTEXT_COMMA cose_errback * errp);
 extern void _COSE_Recipient_Free(COSE_RecipientInfo *);
-extern bool _COSE_Recipient_decrypt(COSE_RecipientInfo * pRecip, COSE_RecipientInfo * pRecipUse, int algIn, int cbitKey, byte * pbKey, cose_errback * errp);
+extern bool _COSE_Recipient_decrypt(COSE_RecipientInfo * pRecip, COSE_RecipientInfo * pRecipUse, int algIn, size_t cbitKey, byte * pbKey, cose_errback * errp);
 extern bool _COSE_Recipient_encrypt(COSE_RecipientInfo * pRecipient, const byte * pbContent, size_t cbContent, cose_errback * perr);
 extern byte * _COSE_RecipientInfo_generateKey(COSE_RecipientInfo * pRecipient, int algIn, size_t cbitKeySize, cose_errback * perr);
 

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -138,7 +138,6 @@ errorReturn:
 	if (cbor_iv_t != NULL) COSE_FREE(cbor_iv_t, context);
 	if (rgbOut != NULL) COSE_FREE(rgbOut, context);
 	if (cnTmp != NULL) COSE_FREE(cnTmp, context);
-	printf("errorReturn from OPENSSL\n");
 	mbedtls_ccm_free(&ctx);
 	return false;
 }
@@ -702,7 +701,7 @@ bool HMAC_Create(COSE_MacMessage * pcose, int HSize, int TSize, const byte * pbK
 	rgbOut = COSE_CALLOC(mbedtls_md_get_size(info), 1, context);
 	CHECK_CONDITION(rgbOut != NULL, COSE_ERR_OUT_OF_MEMORY);
 
-	CHECK_CONDITION(!(mbedtls_md_hmac_starts (&contx, (char*)pbKey, cbKey)), COSE_ERR_CRYPTO_FAIL);
+	CHECK_CONDITION(!(mbedtls_md_hmac_starts (&contx, pbKey, cbKey)), COSE_ERR_CRYPTO_FAIL);
 	CHECK_CONDITION(!(mbedtls_md_hmac_update (&contx, pbAuthData, cbAuthData)), COSE_ERR_CRYPTO_FAIL);
 	CHECK_CONDITION(!(mbedtls_md_hmac_finish (&contx, rgbOut)), COSE_ERR_CRYPTO_FAIL);
 
@@ -741,7 +740,7 @@ bool HMAC_Validate(COSE_MacMessage * pcose, int HSize, int TSize, const byte * p
 	rgbOut = COSE_CALLOC(cbOut, 1, context);
 	CHECK_CONDITION(rgbOut != NULL, COSE_ERR_OUT_OF_MEMORY);
 
-	CHECK_CONDITION(!(mbedtls_md_hmac_starts (&contx, (char*)pbKey, cbKey)), COSE_ERR_CRYPTO_FAIL);
+	CHECK_CONDITION(!(mbedtls_md_hmac_starts (&contx, pbKey, cbKey)), COSE_ERR_CRYPTO_FAIL);
 	CHECK_CONDITION(!(mbedtls_md_hmac_update (&contx, pbAuthData, cbAuthData)), COSE_ERR_CRYPTO_FAIL);
 	CHECK_CONDITION(!(mbedtls_md_hmac_finish (&contx, rgbOut)), COSE_ERR_CRYPTO_FAIL);
 

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -554,6 +554,8 @@ bool HKDF_AES_Expand(COSE * pcose, size_t cbitKey, const byte * pbPRK, size_t cb
 	int cbDigest = 0;
 	byte rgbOut[16];
 
+	UNUSED(pcose);
+
 	EVP_CIPHER_CTX_init(&ctx);
 
 	switch (cbitKey) {
@@ -644,10 +646,11 @@ bool HKDF_Expand(COSE * pcose, size_t cbitDigest, const byte * pbPRK, size_t cbP
 	HMAC_CTX ctx;
 	const EVP_MD * pmd = NULL;
 	size_t ib;
-	int cbSalt;
 	unsigned int cbDigest = 0;
 	byte rgbDigest[EVP_MAX_MD_SIZE];
 	byte bCount = 1;
+
+	UNUSED(pcose);
 
 	HMAC_CTX_init(&ctx);
 
@@ -658,9 +661,9 @@ bool HKDF_Expand(COSE * pcose, size_t cbitDigest, const byte * pbPRK, size_t cbP
 	}
 
 	switch (cbitDigest) {
-	case 256: pmd = EVP_sha256(); cbSalt = 256 / 8;  break;
-	case 384: pmd = EVP_sha384(); cbSalt = 384 / 8; break;
-	case 512: pmd = EVP_sha512(); cbSalt = 512 / 8; break;
+	case 256: pmd = EVP_sha256(); break;
+	case 384: pmd = EVP_sha384(); break;
+	case 512: pmd = EVP_sha512(); break;
 	default: FAIL_CONDITION(COSE_ERR_INVALID_PARAMETER); break;
 	}
 
@@ -1064,6 +1067,8 @@ bool AES_KW_Decrypt(COSE_Enveloped * pcose, const byte * pbKeyIn, size_t cbitKey
 {
 	byte rgbOut[512 / 8];
 	AES_KEY key;
+
+	UNUSED(pcose);
 
 	CHECK_CONDITION(AES_set_decrypt_key(pbKeyIn, (int)cbitKey, &key) == 0, COSE_ERR_CRYPTO_FAIL);
 


### PR DESCRIPTION
Since we have not gotten a fix from cn-cbor yet on this problem, move to a single location of a static buffer for encoding into to get the actual size needed.  Now use just the one 8K buffer.