### PR TITLE
Fix typo in configure.h

### DIFF
--- a/src/configure.h
+++ b/src/configure.h
@@ -1,5 +1,5 @@
 //
-//  Determine which cryptographic library we are goig to be usig
+//  Determine which cryptographic library we are going to be using
 //
 
 #if defined(USE_MBED_TLS)


### PR DESCRIPTION
I found two typos in `configure.h`. This PR fixes the typos.