### PR TITLE
Fix error propagation from ECDSA_Sign

### DIFF
--- a/src/SignerInfo.c
+++ b/src/SignerInfo.c
@@ -202,19 +202,19 @@ bool _COSE_Signer_sign(COSE_SignerInfo * pSigner, const cn_cbor * pcborBody, con
 	switch (alg) {
 #ifdef USE_ECDSA_SHA_256
 	case COSE_Algorithm_ECDSA_SHA_256:
-		f = ECDSA_Sign(&pSigner->m_message, INDEX_SIGNATURE, pSigner->m_pkey, 256, pbToSign, cbToSign, perr);
+		if (!ECDSA_Sign(&pSigner->m_message, INDEX_SIGNATURE, pSigner->m_pkey, 256, pbToSign, cbToSign, perr)) goto errorReturn;
 		break;
 #endif
 
 #ifdef USE_ECDSA_SHA_384
 	case COSE_Algorithm_ECDSA_SHA_384:
-		f = ECDSA_Sign(&pSigner->m_message, INDEX_SIGNATURE, pSigner->m_pkey, 384, pbToSign, cbToSign, perr);
+		if (!ECDSA_Sign(&pSigner->m_message, INDEX_SIGNATURE, pSigner->m_pkey, 384, pbToSign, cbToSign, perr)) goto errorReturn;
 		break;
 #endif
 
 #ifdef USE_ECDSA_SHA_512
 	case COSE_Algorithm_ECDSA_SHA_512:
-		f = ECDSA_Sign(&pSigner->m_message, INDEX_SIGNATURE, pSigner->m_pkey, 512, pbToSign, cbToSign, perr);
+		if (!ECDSA_Sign(&pSigner->m_message, INDEX_SIGNATURE, pSigner->m_pkey, 512, pbToSign, cbToSign, perr)) goto errorReturn;
 		break;
 #endif
 


### PR DESCRIPTION
Errors generated in `ECDSA_sign()` and subcalls are not propagated to the caller of `_COSE_Signer_sign()`. This PR fixes this in a similar method as used by `_COSE_Signer_validate()`. 

### How to reproduce:
Supply a signer key cbor map without `x` and/or `y` items.
### Expected result:
A missing signature and a `false` returned by `COSE_Sign_Sign()`
### Current result:
A silently missing signature in the resulting COSE sign object. Result from `COSE_Sign_Sign()` is `true`