### PR TITLE
Fix incorrect checks of cn_cbor_encoder_write result.

### DIFF
--- a/src/Cose.c
+++ b/src/Cose.c
@@ -207,7 +207,8 @@ errorReturn:
 size_t COSE_Encode(HCOSE msg, byte * rgb, size_t ib, size_t cb)
 {
 	if (rgb == NULL) return cn_cbor_encode_size(((COSE *)msg)->m_cbor) + ib;
-	return cn_cbor_encoder_write(rgb, ib, cb, ((COSE*)msg)->m_cbor);
+	ssize_t size = cn_cbor_encoder_write(rgb, ib, cb, ((COSE*)msg)->m_cbor);
+	return size >= 0 ? size : 0;
 }
 
 

--- a/src/Recipient.c
+++ b/src/Recipient.c
@@ -1341,7 +1341,7 @@ bool BuildContextBytes(COSE * pcose, int algID, size_t cbitKey, byte ** ppbConte
 	CHECK_CONDITION(cbContext > 0, COSE_ERR_CBOR);
 	pbContext = (byte *)COSE_CALLOC(cbContext, 1, context);
 	CHECK_CONDITION(pbContext != NULL, COSE_ERR_OUT_OF_MEMORY);
-	CHECK_CONDITION(cn_cbor_encoder_write(pbContext, 0, cbContext, pArray), COSE_ERR_CBOR);
+	CHECK_CONDITION(cn_cbor_encoder_write(pbContext, 0, cbContext, pArray) == cbContext, COSE_ERR_CBOR);
 
 	*ppbContext = pbContext;
 	*pcbContext = cbContext;

--- a/src/Sign0.c
+++ b/src/Sign0.c
@@ -291,7 +291,7 @@ static bool CreateSign0AAD(COSE_Sign0Message * pMessage, byte ** ppbToSign, size
 	CHECK_CONDITION(cbToSign > 0, COSE_ERR_CBOR);
 	pbToSign = (byte *)COSE_CALLOC(cbToSign, 1, context);
 	CHECK_CONDITION(pbToSign != NULL, COSE_ERR_OUT_OF_MEMORY);
-	CHECK_CONDITION(cn_cbor_encoder_write(pbToSign, 0, cbToSign, pArray), COSE_ERR_CBOR);
+	CHECK_CONDITION(cn_cbor_encoder_write(pbToSign, 0, cbToSign, pArray) == cbToSign, COSE_ERR_CBOR);
 
 	*ppbToSign = pbToSign;
 	*pcbToSign = cbToSign;

--- a/src/SignerInfo.c
+++ b/src/SignerInfo.c
@@ -149,7 +149,7 @@ bool BuildToBeSigned(byte ** ppbToSign, size_t * pcbToSign, const cn_cbor * pcbo
 	CHECK_CONDITION(cbToSign > 0, COSE_ERR_CBOR);
 	pbToSign = (byte *)COSE_CALLOC(cbToSign, 1, context);
 	CHECK_CONDITION(pbToSign != NULL, COSE_ERR_OUT_OF_MEMORY);
-	CHECK_CONDITION(cn_cbor_encoder_write(pbToSign, 0, cbToSign, pArray), COSE_ERR_CBOR);
+	CHECK_CONDITION(cn_cbor_encoder_write(pbToSign, 0, cbToSign, pArray) == cbToSign, COSE_ERR_CBOR);
 
 	*ppbToSign = pbToSign;
 	*pcbToSign = cbToSign;

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -189,5 +189,6 @@ unsigned char RgbDontUse4[8 * 1024];
 
 size_t cn_cbor_encode_size(cn_cbor * object)
 {
-	return cn_cbor_encoder_write(RgbDontUse4, 0, sizeof(RgbDontUse4), object);
+	ssize_t size = cn_cbor_encoder_write(RgbDontUse4, 0, sizeof(RgbDontUse4), object);
+	return size >= 0 ? size : 0;
 }


### PR DESCRIPTION
cn_cbor_encoder_write returns -1 on error. In several cases any
non-zero result was treated as success. In two cases, a -1 result
would be converted to size_t and returned when a 0 result should
be returned.