### PR TITLE
build: allow find package for mbedtls and cn-cbor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
 
 before_build:
   - cmake --version
-  - cmake -Duse_context=%USE_CONTEXT% -Duse_embedtls=%USE_EMBEDTLS% -Dbuild_shared_libs=OFF  -G "Visual Studio 15 2017 Win64" .
+  - cmake -Duse_context=%USE_CONTEXT% -DCOSE_C_USE_MBEDTLS=%USE_EMBEDTLS% -DBUILD_SHARED_LIBS=OFF  -G "Visual Studio 15 2017 Win64" .
 
 build_script:
   - msbuild cose-c.sln

--- a/.gitignore
+++ b/.gitignore
@@ -59,10 +59,11 @@ build
 *.VC.db
 *.VC.opendb
 .vs
+.vscode
 
 # CMake and CTest directories
 project_cn-cbor-prefix
-project_embedtls-prefix
+project_mbedtls-prefix
 Testing
 dist
 test/test.cbor

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ Release
 CMakeFiles
 CMakeCache.txt
 Makefile
-*.cmake
 build
 
 # Visual Studio files

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - cmake --version
   - git clone --depth 1 git://github.com/cose-wg/Examples Examples
   - mkdir build
-  - cd build && cmake -Duse_context=$USE_CONTEXT -Duse_embedtls=$USE_EMBEDTLS $CMAKE_OPTIONS $COVERALLS .. && make all test
+  - cd build && cmake -Duse_context=$USE_CONTEXT -DCOSE_C_USE_MBEDTLS=$USE_EMBEDTLS $CMAKE_OPTIONS $COVERALLS .. && make all test
 
 after_success:
   - make coveralls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option (COSE_C_BUILD_TESTS      "build tests" ON )
 option (COSE_C_BUILD_DUMPER      "build dumper" ON )
 option (BUILD_SHARED_LIBS "Build Shared Libraries" ON)
 option (COSE_C_USE_MBEDTLS    "Use MBedTLS for the Crypto Package" OFF)
+option(COSE_C_USE_FIND_PACKAGE "Use cmake find_package instead of using cmake project_add" OFF)
 option (include_encrypt  "Include COSE_ENCRYPT" ON)
 option (include_encrypt0 "Include COSE_ENCRYPT0" ON)
 option (include_mac      "Include COSE_MAC" ON)
@@ -134,50 +135,60 @@ if (COSE_C_BUILD_DOCS)
    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION share/doc)
 endif()
 
-Include(ExternalProject)
-ExternalProject_Add(
-  project_cn-cbor
-  GIT_REPOSITORY https://github.com/jimsch/cn-cbor
-  GIT_TAG master
-  CMAKE_ARGS -Doptimize=OFF -Duse_context=${use_context} -Dbuild_docs=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -Dfatal_warnings=OFF
-  INSTALL_DIR "${dist_dir}"
-  UPDATE_DISCONNECTED 1
-)
+if(COSE_C_USE_FIND_PACKAGE)
+   find_package(cn-cbor REQUIRED)
+else()
+   include(ExternalProject)
+   ExternalProject_Add(
+   project_cn-cbor
+   GIT_REPOSITORY https://github.com/jimsch/cn-cbor
+   GIT_TAG master
+   CMAKE_ARGS -Doptimize=OFF -Duse_context=${use_context} -Dbuild_docs=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -Dfatal_warnings=OFF
+   INSTALL_DIR "${dist_dir}"
+   UPDATE_DISCONNECTED 1
+   )
 
-ExternalProject_Get_Property(project_cn-cbor install_dir)
-include_directories ( "${install_dir}/include" )
+   ExternalProject_Get_Property(project_cn-cbor install_dir)
+   include_directories ( "${install_dir}/include" )
 
-if (MSVC)
-   add_library (cn-cbor STATIC IMPORTED)
-   set_property (TARGET cn-cbor PROPERTY IMPORTED_LOCATION "${install_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}cn-cbor.lib")
-else ()
-   add_library (cn-cbor STATIC IMPORTED)
-   set_property (TARGET cn-cbor PROPERTY IMPORTED_LOCATION "${install_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}cn-cbor${CMAKE_SHARED_LIBRARY_SUFFIX}")
-endif ()
+   if (MSVC)
+      add_library (cn-cbor STATIC IMPORTED)
+      set_property (TARGET cn-cbor PROPERTY IMPORTED_LOCATION "${install_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}cn-cbor.lib")
+   else ()
+      add_library (cn-cbor STATIC IMPORTED)
+      set_property (TARGET cn-cbor PROPERTY IMPORTED_LOCATION "${install_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}cn-cbor${CMAKE_SHARED_LIBRARY_SUFFIX}")
+   endif ()
 
-add_dependencies(cn-cbor project_cn-cbor)
+   add_dependencies(cn-cbor project_cn-cbor)
+endif()
 
 if (COSE_C_USE_MBEDTLS)
    add_definitions( -DUSE_MBED_TLS )
-   ExternalProject_Add(
-     project_mbedtls
-     GIT_REPOSITORY https://github.com/ARMmbed/mbedtls
-     CMAKE_ARGS -DENABLED_PROGRAMS=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=${BUILD_SHARED_LIBS} -Dfatal_warnings=OFF -DENABLE_TESTING=OFF -DLIB_INSTALL_DIR=${install_dir}/lib
-     INTALL_DIR "${dist_dir}"
-     UPDATE_DISCONNECTED 1
-   )
 
-   ExternalProject_Get_Property(project_mbedtls install_dir)
-   include_directories( "${install_dir}/include" )
-   add_library( mbedtls STATIC IMPORTED)
-   if (MSVC)
-      set_property (TARGET mbedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto.lib")
-   else ()
-      set_property (TARGET mbedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}")
-   endif ()
-   add_dependencies(mbedtls project_mbedtls)
+   if(COSE_C_USE_FIND_PACKAGE)
+      find_package(MbedTLS REQUIRED)
    else()
-      find_package(OpenSSL REQUIRED)
+      ExternalProject_Add(
+         project_mbedtls
+         GIT_REPOSITORY https://github.com/ARMmbed/mbedtls
+         CMAKE_ARGS -DENABLED_PROGRAMS=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=${BUILD_SHARED_LIBS} -Dfatal_warnings=OFF -DENABLE_TESTING=OFF -DLIB_INSTALL_DIR=${install_dir}/lib
+         INTALL_DIR "${dist_dir}"
+         UPDATE_DISCONNECTED 1
+      )
+
+      ExternalProject_Get_Property(project_mbedtls install_dir)
+      include_directories( "${install_dir}/include" )
+      add_library( mbedtls STATIC IMPORTED)
+      if (MSVC)
+         set_property (TARGET mbedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto.lib")
+      else ()
+         set_property (TARGET mbedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      endif ()
+      add_dependencies(mbedtls project_mbedtls)
+   endif()
+
+else()
+   find_package(OpenSSL REQUIRED)
 endif ()
 
 ## include the parts
@@ -207,6 +218,7 @@ message(STATUS "use_context:.........................${use_context}")
 message(STATUS "COSE_C_BUILD_TESTS:..................${COSE_C_BUILD_TESTS}")
 message(STATUS "COSE_C_BUILD_DOCS:...................${COSE_C_BUILD_DOCS}")
 message(STATUS "COSE_C_USE_MBEDTLS:..................${COSE_C_USE_MBEDTLS}")
+message(STATUS "COSE_C_USE_FIND_PACKAGE:.............${COSE_C_USE_FIND_PACKAGE}")
 message(STATUS "COSE_C_BUILD_DUMPER:.................${COSE_C_BUILD_DUMPER}")
 message(STATUS "CMAKE_BUILD_TYPE:....................${CMAKE_BUILD_TYPE}")
 message(STATUS "BUILD_SHARED_LIBS:...................${BUILD_SHARED_LIBS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,6 @@ mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH COSE_VERSION)
 
 project ("cose-c" VERSION "${COSE_VERSION}")
 
-find_package(Doxygen)
-find_package(OpenSSL REQUIRED)
-
 ### setup options
 option (use_context	"Use context pointer for COSE functions" ON)
 option (verbose         "Produce verbose makefile output" OFF)
@@ -23,10 +20,11 @@ option (optimize        "Optimize for size" OFF)
 option (fatal_warnings  "Treat build warnings as error" OFF)
 option (coveralls       "Generate coveralls data" ON)
 option ( coveralls_send "Send data to coveralls site" OFF )
-option (build_docs      "Create docs using Doxygen" ${DOXYGEN_FOUND} )
-option (build_tests      "build tests" ON )
-option (build_shared_libs "Build Shared Libraries" ON)
-option (use_embedtls    "Use MBedTLS for the Crypto Package" OFF)
+option (COSE_C_BUILD_DOCS      "Create docs using Doxygen" OFF )
+option (COSE_C_BUILD_TESTS      "build tests" ON )
+option (COSE_C_BUILD_DUMPER      "build dumper" ON )
+option (BUILD_SHARED_LIBS "Build Shared Libraries" ON)
+option (COSE_C_USE_MBEDTLS    "Use MBedTLS for the Crypto Package" OFF)
 option (include_encrypt  "Include COSE_ENCRYPT" ON)
 option (include_encrypt0 "Include COSE_ENCRYPT0" ON)
 option (include_mac      "Include COSE_MAC" ON)
@@ -104,17 +102,20 @@ else ()
 endif ()
 
 set (LIB_TYPE STATIC)
-if (build_shared_libs)
+if (BUILD_SHARED_LIBS)
    set (LIB_TYPE SHARED)
-endif (build_shared_libs)
+endif (BUILD_SHARED_LIBS)
 
 if (versbose)
    set (CMAKE_VERBOSE_MAKEFILE ON)
 endif ()
 
+###############################################################################
+# DOCS
+###############################################################################
 
-##  try for documentation
-if (build_docs)
+if (COSE_C_BUILD_DOCS)
+   find_package(Doxygen)
    if (NOT DOXYGEN_FOUND)
         message(FATAL_ERROR "Doxygen is needed to build the documenation")
    endif()
@@ -138,7 +139,7 @@ ExternalProject_Add(
   project_cn-cbor
   GIT_REPOSITORY https://github.com/jimsch/cn-cbor
   GIT_TAG master
-  CMAKE_ARGS -Doptimize=OFF -Duse_context=${use_context} -Dbuild_docs=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DBUILD_SHARED_LIBS=${build_shared_libs} -Dfatal_warnings=OFF
+  CMAKE_ARGS -Doptimize=OFF -Duse_context=${use_context} -Dbuild_docs=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -Dfatal_warnings=OFF
   INSTALL_DIR "${dist_dir}"
   UPDATE_DISCONNECTED 1
 )
@@ -156,34 +157,57 @@ endif ()
 
 add_dependencies(cn-cbor project_cn-cbor)
 
-if (use_embedtls)
+if (COSE_C_USE_MBEDTLS)
    add_definitions( -DUSE_MBED_TLS )
    ExternalProject_Add(
-     project_embedtls
+     project_mbedtls
      GIT_REPOSITORY https://github.com/ARMmbed/mbedtls
-     CMAKE_ARGS -DENABLED_PROGRAMS=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=${build_shared_libs} -Dfatal_warnings=OFF -DENABLE_TESTING=OFF -DLIB_INSTALL_DIR=${install_dir}/lib
+     CMAKE_ARGS -DENABLED_PROGRAMS=OFF -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Dcoveralls=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=${BUILD_SHARED_LIBS} -Dfatal_warnings=OFF -DENABLE_TESTING=OFF -DLIB_INSTALL_DIR=${install_dir}/lib
      INTALL_DIR "${dist_dir}"
      UPDATE_DISCONNECTED 1
    )
 
-   ExternalProject_Get_Property(project_embedtls install_dir)
+   ExternalProject_Get_Property(project_mbedtls install_dir)
    include_directories( "${install_dir}/include" )
-   add_library( embedtls STATIC IMPORTED)
+   add_library( mbedtls STATIC IMPORTED)
    if (MSVC)
-      set_property (TARGET embedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto.lib")
+      set_property (TARGET mbedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto.lib")
    else ()
-      set_property (TARGET embedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      set_property (TARGET mbedtls PROPERTY IMPORTED_LOCATION "${dist_dir}/lib/${CMAKE_SHARED_MODULE_PREFIX}mbedcrypto${CMAKE_SHARED_LIBRARY_SUFFIX}")
    endif ()
-   add_dependencies(embedtls project_embedtls)
+   add_dependencies(mbedtls project_mbedtls)
+   else()
+      find_package(OpenSSL REQUIRED)
 endif ()
-
 
 ## include the parts
 add_subdirectory(src)
 add_subdirectory(include)
-add_subdirectory(dumper)
 
-if(build_tests)
+if(COSE_C_BUILD_DUMPER)
+   add_subdirectory(dumper)
+endif()
+
+if(COSE_C_BUILD_TESTS)
    include (CTest)
    add_subdirectory(test)
 endif()
+
+###############################################################################
+# PRINT CONFIG 
+###############################################################################
+
+message(STATUS "include_encrypt:.....................${include_encrypt}")
+message(STATUS "include_encrypt0:....................${include_encrypt0}")
+message(STATUS "include_mac:.........................${include_mac}")
+message(STATUS "include_mac0:........................${include_mac0}")
+message(STATUS "include_sign:........................${include_sign}")
+message(STATUS "include_sign1:.......................${include_sign1}")
+message(STATUS "use_context:.........................${use_context}")
+message(STATUS "COSE_C_BUILD_TESTS:..................${COSE_C_BUILD_TESTS}")
+message(STATUS "COSE_C_BUILD_DOCS:...................${COSE_C_BUILD_DOCS}")
+message(STATUS "COSE_C_USE_MBEDTLS:..................${COSE_C_USE_MBEDTLS}")
+message(STATUS "COSE_C_BUILD_DUMPER:.................${COSE_C_BUILD_DUMPER}")
+message(STATUS "CMAKE_BUILD_TYPE:....................${CMAKE_BUILD_TYPE}")
+message(STATUS "BUILD_SHARED_LIBS:...................${BUILD_SHARED_LIBS}")
+message(STATUS "COSE_VERSION:........................${COSE_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ if (NOT include_sign0)
    set (include_sign1 ${include_sign0})
 endif ()
 
+# Set the output of the libraries and executables.
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
+
 set ( dist_dir          ${CMAKE_BINARY_DIR}/dist )
 set ( prefix            ${CMAKE_INSTALL_PREFIX} )
 set ( exec_prefix       ${CMAKE_INSTALL_PREFIX}/bin )

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,23 @@
+find_path(MBEDTLS_INCLUDE_DIRS mbedtls/ssl.h PATHS "/usr/local" "/usr" "C:/Program Files (x86)/mbed TLS/include")
+
+find_library(MBEDTLS_LIBRARY mbedtls PATHS "C:/Program Files (x86)/mbed TLS/lib")
+find_library(MBEDX509_LIBRARY mbedx509 PATHS "C:/Program Files (x86)/mbed TLS/lib")
+find_library(MBEDCRYPTO_LIBRARY mbedcrypto PATHS "C:/Program Files (x86)/mbed TLS/lib")
+
+set(MBEDTLS_LIBRARIES "${MBEDTLS_LIBRARY}" "${MBEDX509_LIBRARY}" "${MBEDCRYPTO_LIBRARY}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MBEDTLS DEFAULT_MSG MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY
+                                  MBEDCRYPTO_LIBRARY)
+
+mark_as_advanced(MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)
+
+message(STATUS "MBEDTLS_INCLUDE_DIRS: ${MBEDTLS_INCLUDE_DIRS}")
+message(STATUS "MBEDTLS_LIBRARY: ${MBEDTLS_LIBRARY}")
+message(STATUS "MBEDX509_LIBRARY: ${MBEDX509_LIBRARY}")
+message(STATUS "MBEDCRYPTO_LIBRARY: ${MBEDCRYPTO_LIBRARY}")
+message(STATUS "MBEDTLS_LIBRARIES: ${MBEDTLS_LIBRARIES}")
+
+add_library(mbedtls IMPORTED UNKNOWN)
+set_target_properties(mbedtls PROPERTIES IMPORTED_LOCATION ${MBEDTLS_LIBRARIES})
+set_target_properties(mbedtls PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}")

--- a/dumper/CMakeLists.txt
+++ b/dumper/CMakeLists.txt
@@ -20,14 +20,14 @@ target_link_libraries( cose_dumper PRIVATE ${OPENSSL_LIBRARIES} )
 target_link_libraries( cose_dumper PRIVATE cn-cbor )
 
 if ( MSVC )
-   message ( "test: ${build_shared_libs}")
+   message ( "test: ${BUILD_SHARED_LIBS}")
    message ( "verbose: ${verbose}")
 
 target_link_libraries( cose_dumper PRIVATE ws2_32 )
 endif ()
-if (use_embedtls)
-    target_include_directories ( cose_dumper PUBLIC ${CMAKE_SHARED_MODLE_PREFIX}embedtls${CMAKE_SHARED_LIBRARY_SUFFIX}/include )
-    target_link_libraries ( cose_dumper PRIVATE embedtls )
+if (COSE_C_USE_MBEDTLS)
+    target_include_directories ( cose_dumper PUBLIC ${CMAKE_SHARED_MODLE_PREFIX}mbedtls${CMAKE_SHARED_LIBRARY_SUFFIX}/include )
+    target_link_libraries ( cose_dumper PRIVATE mbedtls )
 endif()
 
 target_include_directories ( cose_dumper PRIVATE ../include )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 #  compiling/installing sources for COSE-C
 #
 
-if (use_embedtls)
+if (COSE_C_USE_MBEDTLS)
   set (cose_crypto mbedtls.c)
 else ()
   set (cose_crypto openssl.c)
@@ -41,9 +41,9 @@ target_include_directories ( cose-c PRIVATE ../src )
 
 target_link_libraries ( cose-c PRIVATE ${OPENSSL_LIBRARIES} )
 target_link_libraries ( cose-c PRIVATE cn-cbor )
-if (use_embedtls)
-    target_include_directories ( cose-c PUBLIC ${CMAKE_SHARED_MODLE_PREFIX}embedtls${CMAKE_SHARED_LIBRARY_SUFFIX}/include )
-    target_link_libraries ( cose-c PRIVATE embedtls )
+if (COSE_C_USE_MBEDTLS)
+    target_include_directories ( cose-c PUBLIC ${CMAKE_SHARED_MODLE_PREFIX}mbedtls${CMAKE_SHARED_LIBRARY_SUFFIX}/include )
+    target_link_libraries ( cose-c PRIVATE mbedtls )
 endif()
 
 if ( MSVC )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,8 +11,8 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${dist_dir}/test )
 add_executable ( cose_test test.c json.c encrypt.c sign.c context.c mac_test.c)
 
 target_link_libraries (cose_test PRIVATE cose-c )
-if (use_embedtls)
-    target_link_libraries ( cose_test PRIVATE embedtls )
+if (COSE_C_USE_MBEDTLS)
+    target_link_libraries ( cose_test PRIVATE mbedtls )
 endif()
 
 ## OpenSSL


### PR DESCRIPTION
depends on https://github.com/cose-wg/COSE-C/pull/75 -> please merge it before this one

# what:
allows users to choose between fetching and building dependencies with this library or to find existing libs in the sys root and use them

# why:
this is important for packaging, e.g. debian, yocto, conan
when linking this lib to an executable which links already to another version of mbedtls -> undefined behaviour