### PR TITLE
refactor: create configure.h at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 if(NOT COSE_C_INCLUDE_SIGN1)
   add_definitions(-DINCLUDE_SIGN1=0)
 endif()
-if (NOT COSE_C_INCLUDE_COUNTERSIGN)
+if(NOT COSE_C_INCLUDE_COUNTERSIGN)
   add_definitions(-DINCLUDE_COUNTERSIGN=0)
 endif()
 if(COSE_C_USE_CONTEXT)
@@ -98,8 +98,8 @@ if(versbose)
 endif()
 
 # Control the order of packages - get the latest not the first
-SET(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
-SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 
 ###############################################################################
 # DOCS
@@ -186,7 +186,8 @@ else()
 endif()
 
 if(COSE_C_USE_MBEDTLS)
-  add_definitions(-DUSE_MBED_TLS)
+  add_definitions(-DCOSE_C_USE_MBEDTLS)
+  set(COSE_C_USE_OPENSSL OFF)
 
   if(COSE_C_USE_FIND_PACKAGE)
     find_package(MbedTLS)
@@ -219,6 +220,7 @@ if(COSE_C_USE_MBEDTLS)
   endif()
 else()
   find_package(OpenSSL REQUIRED)
+  set(COSE_C_USE_OPENSSL ON)
 endif()
 
 ###############################################################################
@@ -272,3 +274,5 @@ message(STATUS "CMAKE_CXX_COMPILER:..............${CMAKE_CXX_COMPILER}")
 message(STATUS "CLANG_TIDY_EXE:..................${CLANG_TIDY_EXE}")
 message(STATUS "project_cn_cbor_SOURCE_DIR:......${project_cn_cbor_SOURCE_DIR}")
 message(STATUS "project_cn_cbor_BINARY_DIR:......${project_cn_cbor_BINARY_DIR}")
+message(STATUS "project_mbedtls_SOURCE_DIR:......${project_mbedtls_SOURCE_DIR}")
+message(STATUS "project_mbedtls_BINARY_DIR:......${project_mbedtls_BINARY_DIR}")

--- a/include/cose/cose_configure.h.in
+++ b/include/cose/cose_configure.h.in
@@ -10,18 +10,18 @@
 
 // make sure we only use one crypto library
 #if defined(COSE_C_USE_MBEDTLS)
-	#if defined(COSE_C_USE_OPENSSL) || defined(COSE_C_USE_BCRYPT)
-		#error Only Define One Crypto Package
-	#endif
+#if defined(COSE_C_USE_OPENSSL) || defined(COSE_C_USE_BCRYPT)
+#error Only Define One Crypto Package
+#endif
 #elif defined(COSE_C_USE_BCRYPT)
-	#if defined(COSE_C_USE_OPENSSL)
-		#error Only Define One Crypto Package
-	#endif
+#if defined(COSE_C_USE_OPENSSL)
+#error Only Define One Crypto Package
+#endif
 #endif
 
 // verify that we have a supported version of openssl
 #if defined(COSE_C_USE_OPENSSL)
-	#include <openssl/opensslv.h>
+#include <openssl/opensslv.h>
 #endif
 
 //
@@ -76,7 +76,7 @@
 #define USE_AES_CBC_MAC_256_64
 #define USE_AES_CBC_MAC_256_128
 
-#endif	// !defined(COSE_C_USE_MBEDTLS)
+#endif  // !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which ECDH algorithms are to be used
@@ -92,7 +92,7 @@
 #define USE_ECDH 1
 #define USE_HKDF_SHA2 1
 #endif
-#endif	// !defined(COSE_C_USE_MBEDTLS)
+#endif  // !defined(COSE_C_USE_MBEDTLS)
 
 #if !defined(COSE_C_USE_MBEDTLS)
 #define USE_ECDH_ES_A128KW
@@ -107,7 +107,7 @@
 #define USE_ECDH 1
 #define USE_HKDF_AES 1
 #endif
-#endif	// !defined(COSE_C_USE_MBEDTLS)
+#endif  // !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which Key Wrap functions are to be used
@@ -117,7 +117,7 @@
 #define USE_AES_KW_128
 #define USE_AES_KW_192
 #define USE_AES_KW_256
-#endif	// !defined(COSE_C_USE_MBEDTLS)
+#endif  // !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which of the DIRECT + KDF algorithms are to be used
@@ -135,7 +135,7 @@
 #if defined(USE_Direct_HKDF_AES_128) || defined(USE_Direct_KDF_AES_256)
 #define USE_HKDF_AES 1
 #endif
-#endif	// !defined(COSE_C_USE_MBEDTLS)
+#endif  // !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which of the signature algorithms are to be used
@@ -145,16 +145,16 @@
 #define USE_ECDSA_SHA_384
 #define USE_ECDSA_SHA_512
 #if defined(COSE_C_USE_OPENSSL)
-	//  MBEDTLS currently supports ECDH for X25519 but not EdDSA
-	#if OPENSSL_VERSION_NUMBER > 0x10100000L
-		// Requires OPEN SSL 1.1.1 to build
-		#define USE_EDDSA
-	#else
-		#define STRINGIFY(x) #x
-		#define TOSTRING(x) STRINGIFY(x)
-		#pragma message("OPENSSL VERSION IS " OPENSSL_VERSION_TEXT)
-	#endif
-#endif	// !defined (COSE_C_USE_MBEDTLS)
+//  MBEDTLS currently supports ECDH for X25519 but not EdDSA
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+// Requires OPEN SSL 1.1.1 to build
+#define USE_EDDSA
+#else
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#pragma message("OPENSSL VERSION IS " OPENSSL_VERSION_TEXT)
+#endif
+#endif  // !defined (COSE_C_USE_MBEDTLS)
 
 //
 //   Define which COSE objects are included

--- a/include/cose/cose_configure.h.in
+++ b/include/cose/cose_configure.h.in
@@ -154,7 +154,7 @@
 #define TOSTRING(x) STRINGIFY(x)
 #pragma message("OPENSSL VERSION IS " OPENSSL_VERSION_TEXT)
 #endif
-#endif  // !defined (COSE_C_USE_MBEDTLS)
+#endif  // defined (COSE_C_USE_OPENSSL)
 
 //
 //   Define which COSE objects are included

--- a/include/cose/cose_configure.h.in
+++ b/include/cose/cose_configure.h.in
@@ -4,17 +4,21 @@
 
 #pragma once
 
-#if defined(USE_MBED_TLS)
-#if defined(USE_OPEN_SSL) || defined(USE_BCRYPT)
+#cmakedefine COSE_C_USE_MBEDTLS
+#cmakedefine COSE_C_USE_OPENSSL
+#cmakedefine COSE_C_USE_BCRYPT
+
+#if defined(COSE_C_USE_MBEDTLS)
+#if defined(COSE_C_USE_OPENSSL) || defined(COSE_C_USE_BCRYPT)
 #error Only Define One Crypto Package
 #endif
-#elif defined(USE_BCRYPT)
-#if defined(USE_OPENSSL)
+#elif defined(COSE_C_USE_BCRYPT)
+#if defined(COSE_C_USE_OPENSSL)
 #error Only Define One Crypto Package
 #endif
-#elif !defined(USE_OPEN_SSL)
+#elif !defined(COSE_C_USE_OPENSSL)
 #include <openssl/opensslv.h>
-#define USE_OPEN_SSL
+#define COSE_C_USE_OPENSSL
 #endif
 
 //
@@ -62,20 +66,20 @@
 //  Define which AES CBC-MAC algorithms are to be used
 //
 
-#if !defined(USE_MBED_TLS)
+#if !defined(COSE_C_USE_MBEDTLS)
 
 #define USE_AES_CBC_MAC_128_64
 #define USE_AES_CBC_MAC_128_128
 #define USE_AES_CBC_MAC_256_64
 #define USE_AES_CBC_MAC_256_128
 
-#endif	// !defined(USE_MBED_TLS)
+#endif	// !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which ECDH algorithms are to be used
 //
 
-#if !defined(USE_MBED_TLS)
+#if !defined(COSE_C_USE_MBEDTLS)
 #define USE_ECDH_ES_HKDF_256
 #define USE_ECDH_ES_HKDF_512
 #define USE_ECDH_SS_HKDF_256
@@ -85,9 +89,9 @@
 #define USE_ECDH 1
 #define USE_HKDF_SHA2 1
 #endif
-#endif	// !defined(USE_MBED_TLS)
+#endif	// !defined(COSE_C_USE_MBEDTLS)
 
-#if !defined(USE_MBED_TLS)
+#if !defined(COSE_C_USE_MBEDTLS)
 #define USE_ECDH_ES_A128KW
 #define USE_ECDH_ES_A192KW
 #define USE_ECDH_ES_A256KW
@@ -100,23 +104,23 @@
 #define USE_ECDH 1
 #define USE_HKDF_AES 1
 #endif
-#endif	// !defined(USE_MBED_TLS)
+#endif	// !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which Key Wrap functions are to be used
 //
 
-#if !defined(USE_MBED_TLS)
+#if !defined(COSE_C_USE_MBEDTLS)
 #define USE_AES_KW_128
 #define USE_AES_KW_192
 #define USE_AES_KW_256
-#endif	// !defined(USE_MBED_TLS)
+#endif	// !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which of the DIRECT + KDF algorithms are to be used
 //
 
-#if !defined(USE_MBED_TLS)
+#if !defined(COSE_C_USE_MBEDTLS)
 #define USE_Direct_HKDF_HMAC_SHA_256
 #define USE_Direct_HKDF_HMAC_SHA_512
 #define USE_Direct_HKDF_AES_128
@@ -128,7 +132,7 @@
 #if defined(USE_Direct_HKDF_AES_128) || defined(USE_Direct_KDF_AES_256)
 #define USE_HKDF_AES 1
 #endif
-#endif	// !defined(USE_MBED_TLS)
+#endif	// !defined(COSE_C_USE_MBEDTLS)
 
 //
 //  Define which of the signature algorithms are to be used
@@ -137,7 +141,7 @@
 #define USE_ECDSA_SHA_256
 #define USE_ECDSA_SHA_384
 #define USE_ECDSA_SHA_512
-#if !defined(USE_MBED_TLS)
+#if !defined(COSE_C_USE_MBEDTLS)
 //  MBEDTLS currently supports ECDH for X25519 but not EdDSA
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
 // Requires OPEN SSL 1.1.1 to build
@@ -147,7 +151,7 @@
 #define TOSTRING(x) STRINGIFY(x)
 #pragma message("OPENSSL VERSION IS " OPENSSL_VERSION_TEXT)
 #endif
-#endif	// !defined (USE_MBED_TLS)
+#endif	// !defined (COSE_C_USE_MBEDTLS)
 
 //
 //   Define which COSE objects are included

--- a/include/cose/cose_configure.h.in
+++ b/include/cose/cose_configure.h.in
@@ -8,17 +8,20 @@
 #cmakedefine COSE_C_USE_OPENSSL
 #cmakedefine COSE_C_USE_BCRYPT
 
+// make sure we only use one crypto library
 #if defined(COSE_C_USE_MBEDTLS)
-#if defined(COSE_C_USE_OPENSSL) || defined(COSE_C_USE_BCRYPT)
-#error Only Define One Crypto Package
-#endif
+	#if defined(COSE_C_USE_OPENSSL) || defined(COSE_C_USE_BCRYPT)
+		#error Only Define One Crypto Package
+	#endif
 #elif defined(COSE_C_USE_BCRYPT)
-#if defined(COSE_C_USE_OPENSSL)
-#error Only Define One Crypto Package
+	#if defined(COSE_C_USE_OPENSSL)
+		#error Only Define One Crypto Package
+	#endif
 #endif
-#elif !defined(COSE_C_USE_OPENSSL)
-#include <openssl/opensslv.h>
-#define COSE_C_USE_OPENSSL
+
+// verify that we have a supported version of openssl
+#if defined(COSE_C_USE_OPENSSL)
+	#include <openssl/opensslv.h>
 #endif
 
 //
@@ -141,16 +144,16 @@
 #define USE_ECDSA_SHA_256
 #define USE_ECDSA_SHA_384
 #define USE_ECDSA_SHA_512
-#if !defined(COSE_C_USE_MBEDTLS)
-//  MBEDTLS currently supports ECDH for X25519 but not EdDSA
-#if OPENSSL_VERSION_NUMBER > 0x10100000L
-// Requires OPEN SSL 1.1.1 to build
-#define USE_EDDSA
-#else
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-#pragma message("OPENSSL VERSION IS " OPENSSL_VERSION_TEXT)
-#endif
+#if defined(COSE_C_USE_OPENSSL)
+	//  MBEDTLS currently supports ECDH for X25519 but not EdDSA
+	#if OPENSSL_VERSION_NUMBER > 0x10100000L
+		// Requires OPEN SSL 1.1.1 to build
+		#define USE_EDDSA
+	#else
+		#define STRINGIFY(x) #x
+		#define TOSTRING(x) STRINGIFY(x)
+		#pragma message("OPENSSL VERSION IS " OPENSSL_VERSION_TEXT)
+	#endif
 #endif	// !defined (COSE_C_USE_MBEDTLS)
 
 //

--- a/scripts/format_source.sh
+++ b/scripts/format_source.sh
@@ -37,7 +37,7 @@ find "$PROJECT_PATH" \
 -not \( -path "*/third_party/*" -prune \) \
 -not \( -path "*Coverity_Model.c*" -prune \) \
 -not \( -path "*/docs/*" -prune \) \
-\( -name "*.h" -o -name "*.hpp" -o -name "*.c" -o -name "*.cpp" \) \
+\( -name "*.h.in" -o -name "*.h" -o -name "*.hpp" -o -name "*.c" -o -name "*.cpp" \) \
 | xargs $format -i
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,11 @@ endif()
 
 add_library(${PROJECT_NAME})
 
+# some structs look differently depending on the crypto lib used
+# therefore we create the config header file at configure time.
+configure_file(${CMAKE_CURRENT_LIST_DIR}/../include/cose/cose_configure.h.in
+               ${CMAKE_BINARY_DIR}/include/cose/cose_configure.h)
+
 if(COSE_C_USE_MBEDTLS)
   set(cose_crypto mbedtls.c)
 else()
@@ -30,7 +35,7 @@ endif()
 
 set(cose_sources
     ${PROJECT_SOURCE_DIR}/include/cose/cose.h
-    ${PROJECT_SOURCE_DIR}/include/cose/cose_configure.h
+    ${CMAKE_BINARY_DIR}/include/cose/cose_configure.h
     crypto.h
     cose_int.h
     crypto.h
@@ -52,7 +57,8 @@ target_sources(${PROJECT_NAME} PRIVATE ${cose_sources})
 
 target_include_directories(
   ${PROJECT_NAME}
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+         $<INSTALL_INTERFACE:include>
   PRIVATE ../src)
 target_link_libraries(${PROJECT_NAME} PRIVATE cn-cbor::cn-cbor)
 
@@ -121,6 +127,12 @@ install(
 
 install(
   DIRECTORY ${PROJECT_SOURCE_DIR}/include/cose
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  COMPONENT dev
+  FILES_MATCHING
+  PATTERN "*.h")
+install(
+  DIRECTORY ${CMAKE_BINARY_DIR}/include/cose
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   COMPONENT dev
   FILES_MATCHING

--- a/src/Sign1.c
+++ b/src/Sign1.c
@@ -1,4 +1,4 @@
-/** \file Sign.c
+/** \file Sign1.c
  * Contains implementation of the functions related to HCOSE_SIGN handle
  * objects.
  */
@@ -12,10 +12,10 @@
 
 #if INCLUDE_SIGN1
 
-bool _COSE_Signer0_sign(COSE_Sign1Message *pSigner,
+bool _COSE_Signer1_sign(COSE_Sign1Message *pSigner,
 	const cn_cbor *pKey,
 	cose_errback *perr);
-bool _COSE_Signer0_validate(COSE_Sign1Message *pSign,
+bool _COSE_Signer1_validate(COSE_Sign1Message *pSign,
 	const cn_cbor *pKey,
 	cose_errback *perr);
 void _COSE_Sign1_Release(COSE_Sign1Message *p);
@@ -237,7 +237,7 @@ bool COSE_Sign1_Sign(HCOSE_SIGN1 h, const cn_cbor *pKey, cose_errback *perr)
 		goto errorReturn;
 	}
 
-	if (!_COSE_Signer0_sign(pMessage, pKey, perr)) {
+	if (!_COSE_Signer1_sign(pMessage, pKey, perr)) {
 		goto errorReturn;
 	}
 
@@ -274,7 +274,7 @@ bool COSE_Sign1_validate(HCOSE_SIGN1 hSign,
 	CHECK_CONDITION(cnProtected != NULL && cnProtected->type == CN_CBOR_BYTES,
 		COSE_ERR_INVALID_PARAMETER);
 
-	f = _COSE_Signer0_validate(pSign, pKey, perr);
+	f = _COSE_Signer1_validate(pSign, pKey, perr);
 
 	return f;
 
@@ -405,7 +405,7 @@ errorReturn:
 	return false;
 }
 
-bool _COSE_Signer0_sign(COSE_Sign1Message *pSigner,
+bool _COSE_Signer1_sign(COSE_Sign1Message *pSigner,
 	const cn_cbor *pKey,
 	cose_errback *perr)
 {
@@ -501,7 +501,7 @@ bool _COSE_Signer0_sign(COSE_Sign1Message *pSigner,
 	return f;
 }
 
-bool _COSE_Signer0_validate(COSE_Sign1Message *pSign,
+bool _COSE_Signer1_validate(COSE_Sign1Message *pSign,
 	const cn_cbor *pKey,
 	cose_errback *perr)
 {

--- a/src/bcrypt.c
+++ b/src/bcrypt.c
@@ -3,7 +3,7 @@
 #include "cose_int.h"
 #include "crypto.h"
 
-#if USE_BCRYPT
+#if COSE_C_USE_BCRYPT
 
 #include <Windows.h>
 
@@ -77,4 +77,4 @@ bool AES_CCM_Encrypt(COSE_Encrypt *pcose,
 	return true;
 }
 
-#endif	// USE_BCRYPT
+#endif	// COSE_C_USE_BCRYPT

--- a/src/mbedtls.c
+++ b/src/mbedtls.c
@@ -9,7 +9,7 @@
 #endif
 #include <stdlib.h>
 
-#ifdef USE_MBED_TLS
+#ifdef COSE_C_USE_MBEDTLS
 
 #include "mbedtls/ccm.h"
 #include "mbedtls/md.h"
@@ -1600,4 +1600,4 @@ errorReturn:
 	return fRet;
 }
 #endif	// USE_ECDH
-#endif	// USE_MBED_TLS
+#endif	// COSE_C_USE_MBEDTLS

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -7,7 +7,7 @@
 #include <memory.h>
 #include <stdbool.h>
 
-#ifdef USE_OPEN_SSL
+#ifdef COSE_C_USE_OPENSSL
 
 #include <openssl/evp.h>
 #include <openssl/aes.h>
@@ -1779,4 +1779,4 @@ errorReturn:
 	return fRet;
 }
 
-#endif	// USE_OPEN_SSL
+#endif	// COSE_C_USE_OPENSSL

--- a/test/test.c
+++ b/test/test.c
@@ -21,7 +21,7 @@
 #include "json.h"
 #include "test.h"
 
-#ifdef USE_MBED_TLS
+#ifdef COSE_C_USE_MBEDTLS
 #include "mbedtls/entropy.h"
 #endif
 
@@ -1315,7 +1315,7 @@ int main(int argc, char** argv)
 		}
 	}
 
-#ifdef USE_MBED_TLS
+#ifdef COSE_C_USE_MBEDTLS
 	mbedtls_entropy_context entropy;
 	mbedtls_entropy_init(&entropy);
 #endif


### PR DESCRIPTION
similiar to what autoconf does, with cmake

creates a `cose_configure.h` at compile time e.g. the defines are created by cmake