### PR TITLE
Report correct unencrypted length

### DIFF
--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -430,7 +430,7 @@ bool AES_GCM_Decrypt(COSE_Enveloped *pcose,
 	EVP_CIPHER_CTX_free(ctx);
 
 	pcose->pbContent = rgbOut;
-	pcose->cbContent = cbOut;
+	pcose->cbContent = (int)cbCrypto - TSize;
 
 	return true;
 }


### PR DESCRIPTION
COSE_Encrypt_GetContent() returns a valid pointer to the content, but the length parameter is set to 0.

The reason for this is because cbOut is set to the correct value, but is then used as the remaining bytes in the EVP functions and gets set to 0.

This PR sets the output parameter to the correct value, so we can use the payload safely.