### PR TITLE
fix const strip (build error) - openssl.cpp

### DIFF
--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -2004,7 +2004,7 @@ bool ECDH_ComputeSecret(COSE *pRecipient,
 		switch (type) {
 			case EVP_PKEY_EC: {
 				EC_KEY *peckeyPrivate = EC_KEY_new();
-				EC_KEY *peckeyPublic = EVP_PKEY_get0_EC_KEY(evpPublic);
+				const EC_KEY *peckeyPublic = EVP_PKEY_get0_EC_KEY(evpPublic);
 				EC_KEY_set_group(
 					peckeyPrivate, EC_KEY_get0_group(peckeyPublic));
 				CHECK_CONDITION(EC_KEY_generate_key(peckeyPrivate) == 1,


### PR DESCRIPTION
fix this conversion error:

```make
/home/user/greenpass_qrcode_reader/build/_deps/cose-c-src/src/openssl.cpp:2007:76: error: invalid conversion from ‘const ec_key_st*’ to ‘EC_KEY*’ {aka ‘ec_key_st*’} [-fpermissive]
 2007 |                                 EC_KEY *peckeyPublic = EVP_PKEY_get0_EC_KEY(evpPublic);
      |                                                        ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
      |                                                                            |
      |                                                                            const ec_key_st*
```

![Schermata del 2023-09-19 12-41-00](https://github.com/cose-wg/COSE-C/assets/13910080/61aea38a-dec7-4780-9b7b-0d81dd74dec3)
